### PR TITLE
If you deactivate ACF, large errors will occur

### DIFF
--- a/acf-page-builder-field.php
+++ b/acf-page-builder-field.php
@@ -100,6 +100,10 @@ class ACF_Page_Builder {
         if( function_exists( 'siteorigin_panels_render' ) && class_exists( 'acf' ) ) {
             return true;
         } else if ( $already_activated ) {
+            if( ! function_exists( 'deactivate_plugins' ) ){
+                require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+            }
+            
             deactivate_plugins( plugin_basename( __FILE__ ) );
         } else {
             wp_die(


### PR DESCRIPTION
If you deactivate ACF, deactivate_plugins() is called before the function actually exists. So as a result of this, the plugin will constantly be trying to deactivate itself but will be unable to as it doesn't exist. As a result of this issue, the site will be unusable until you manually remove the plugin.

I did a function_exists check so that in the odd instance that deactivate_plugins() does exist, it won't error.